### PR TITLE
heroku config rollbacked, blocks local runs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ java {
 
 application {
     mainClass.set("com.tomasguinzburg.demo.impl.application.App")
-    applicationDefaultJvmArgs = mutableListOf("-XX:+UseContainerSupport")
+//    applicationDefaultJvmArgs = mutableListOf("-XX:+UseContainerSupport")  Affects running locally, should only be applied in stage task
 }
 
 jacoco {


### PR DESCRIPTION
Heroku VM options were incompatible with running the code locally. Commented until a solution is found for adding them only in container environments. Heroku is deployed from master anyway.